### PR TITLE
Manifest GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,14 @@ jobs:
       with:
         node-version: '20'
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install Python setup tools
+      run: |
+          pip install setuptools
+
     - name: Install dependencies
       run: npm install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-        cache: 'pip'
     - name: Install Python setup tools
       run: |
           pip install setuptools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: "Build - ${{ matrix.os }}"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: npm run build
+
+    - name: Test
+      run: npm test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,14 @@ jobs:
       with:
         node-version: '20'
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install Python setup tools
+      run: |
+          pip install setuptools
+
     - name: Install dependencies
       run: npm install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -23,13 +24,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-    - name: Install Python setup tools
-      run: |
-          pip install setuptools
 
     - name: Install dependencies
       run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,11 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    name: "Build - ${{ matrix.os }}"
+    name: "Release - ${{ matrix.os }}"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - '*'
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ jobs:
       with:
         node-version: '20'
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install Python setup tools
+      run: |
+          pip install setuptools
+
     - name: Install dependencies
       run: npm install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: "Build - ${{ matrix.os }}"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: npm run build
+
+    - name: Create release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: dist/*
+        tag_name: ${{ github.ref }}
+        name: ${{ github.ref }}
+        body: |
+          This is a release for version ${{ github.ref }}.
+          It contains the compiled files from the build process.


### PR DESCRIPTION
Manifest workflows, just to get checks of building and releases at least created.

This will need to be adjusted for CI to pass as well as fit our requirements for building and distribution.