### PR TITLE
Add macOS and Linux support, fix Windows build Regression

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
       'sources': [
         'src/addon.cc',
         'src/canWrapper.cc',
-       ],
+      ],
       'include_dirs': [
         "src/",
         "externalCompileTimeDeps/include",
@@ -15,21 +15,46 @@
         "NAPI_VERSION=<(napi_build_version)"
       ],
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
-      'libraries': [
-            # These files were placed by download-CanBridge.mjs
-            '<(module_root_dir)/externalCompileTimeDeps/CANBridge.lib',
-            '<(module_root_dir)/externalCompileTimeDeps/wpiHal.lib',
-            '<(module_root_dir)/externalCompileTimeDeps/wpiutil.lib',
+      'conditions': [
+        ['OS=="mac"', {
+            'libraries': [
+                # These files were placed by download-CanBridge.mjs
+                '<(module_root_dir)/externalCompileTimeDeps/libCANBridge.a',
+            ],
+            'copies': [{
+                'destination': './build/Release',
+                'files': [
+                    # These files were placed in the prebuilds folder by download-CanBridge.mjs
+                    '<(module_root_dir)/prebuilds/darwin-x64/libCANBridge.dylib',
+                    '<(module_root_dir)/prebuilds/darwin-x64/libwpiHal.dylib',
+                    '<(module_root_dir)/prebuilds/darwin-x64/libwpiutil.dylib',
+                ]
+            }],
+        }],
+        ['OS=="win"', {
+            'libraries': [
+                # These files were placed by download-CanBridge.mjs
+                '<(module_root_dir)/externalCompileTimeDeps/CANBridge.lib',
+                '<(module_root_dir)/externalCompileTimeDeps/wpiHal.lib',
+                '<(module_root_dir)/externalCompileTimeDeps/wpiutil.lib',
+            ],
+        }],
+        ['OS=="linux"', {
+            'libraries': [
+                # These files were placed by download-CanBridge.mjs
+                '<(module_root_dir)/externalCompileTimeDeps/libCANBridge.a',
+            ],
+            'copies': [{
+                'destination': './build/Release',
+                'files': [
+                    # These files were placed in the prebuilds folder by download-CanBridge.mjs
+                    '<(module_root_dir)/prebuilds/linux-x64/libCANBridge.so',
+                    '<(module_root_dir)/prebuilds/linux-x64/libwpiHal.so',
+                    '<(module_root_dir)/prebuilds/linux-x64/libwpiutil.so',
+                ]
+            }],
+        }],
       ],
-      'copies': [{
-        'destination': './build/Release',
-        'files': [
-          # These files were placed in the prebuilds folder by download-CanBridge.mjs
-          '<(module_root_dir)/prebuilds/win32-x64/CANBridge.dll',
-          '<(module_root_dir)/prebuilds/win32-x64/wpiHal.dll',
-          '<(module_root_dir)/prebuilds/win32-x64/wpiutil.dll',
-        ]
-      }],
       'msvs_settings': {
         'VCCLCompilerTool': {
             'ExceptionHandling': 1,

--- a/binding.gyp
+++ b/binding.gyp
@@ -66,8 +66,8 @@
           "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
           "OTHER_CPLUSPLUSFLAGS": ["-fexceptions"]
       },
-      "cflags_cc!": ["-std=c++20", '-fno-exceptions'],
-      "cflags!": ["-std=c++20", '-fno-exceptions'],
+      "cflags_cc": ["-std=c++20", '-fexceptions'],
+      "cflags": ["-std=c++20", '-fexceptions'],
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,6 +38,15 @@
                 '<(module_root_dir)/externalCompileTimeDeps/wpiHal.lib',
                 '<(module_root_dir)/externalCompileTimeDeps/wpiutil.lib',
             ],
+            'copies': [{
+                'destination': './build/Release',
+                'files': [
+                    # These files were placed in the prebuilds folder by download-CanBridge.mjs
+                    '<(module_root_dir)/prebuilds/win32-x64/CANBridge.dll',
+                    '<(module_root_dir)/prebuilds/win32-x64/wpiHal.dll',
+                    '<(module_root_dir)/prebuilds/win32-x64/wpiutil.dll',
+                ]
+            }],
         }],
         ['OS=="linux"', {
             'libraries': [

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
         "typescript": "^5.0.2"
     },
     "scripts": {
-        "install": "node-gyp-build \"node scripts/download-CanBridge.mjs\"",
+        "install": "node scripts/download-CanBridge.mjs && node-gyp rebuild",
         "prepublishOnly": "node scripts/download-CanBridge.mjs && tsc && prebuildify --napi",
-        "pretest": "node-gyp-build && tsc",
+        "pretest": "node-gyp rebuild && tsc",
         "test": "node --napi-modules test/test_binding.js"
     },
     "engines": {

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -4,7 +4,7 @@ import axios from 'axios';
 import AdmZip from 'adm-zip';
 
 const canBridgeTag = "v2.3.0";
-const canBridgeReleaseAssetUrlPrefix = `https://github.com/REVrobotics/CANBridge/releases/download/${canBridgeTag}`;
+const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';
 const runtimeArtifactsPath = path.join('prebuilds', 'win32-x64');

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -2,47 +2,128 @@ import * as fs from "fs";
 import * as path from "path";
 import axios from 'axios';
 import AdmZip from 'adm-zip';
+import { platform, arch } from 'os';
 
-const canBridgeTag = "v2.3.0";
+const canBridgeTag = "v2.3.1";
 const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';
-const runtimeArtifactsPath = path.join('prebuilds', 'win32-x64');
+const runtimeArtifactsPath = {
+    win: 'prebuilds/win32-x64',
+    osx: 'prebuilds/darwin-x64',
+    osxArm: 'prebuilds/darwin-arm64',
+    linux: 'prebuilds/linux-x64',
+    linuxArm: 'prebuilds/linux-arm64',
+    linuxArm32: 'prebuilds/linux-arm32'
+};
 const tempDir = 'temp';
 
 try {
-    await Promise.all(Array.of(
-        downloadCanBridgeArtifact('CANBridge.lib', externalCompileTimeDepsPath),
-        downloadCanBridgeArtifact('CANBridge.dll', runtimeArtifactsPath),
-        downloadCanBridgeArtifact('wpiHal.lib', externalCompileTimeDepsPath),
-        downloadCanBridgeArtifact('wpiHal.dll', runtimeArtifactsPath),
-        downloadCanBridgeArtifact('wpiutil.lib', externalCompileTimeDepsPath),
-        downloadCanBridgeArtifact('wpiutil.dll', runtimeArtifactsPath),
-        downloadCanBridgeArtifact('headers.zip', tempDir),
-    ));
-
+    // TODO: Do not hardcode the filenames, instead get them from the GitHub API -> Look at Octokit: https://github.com/octokit/octokit.js
+    await Promise.all([
+        'CANBridge-linuxarm32-LinuxARM32.zip',
+        'CANBridge-linuxarm64-LinuxARM64.zip',
+        'CANBridge-linuxx86-64-Linux64.zip',
+        'CANBridge-osxuniversal-MacOS64.zip',
+        'CANBridge-osxuniversal-MacOSARM64.zip',
+        'CANBridge-windowsx86-64-Win64.zip',
+        'headers.zip'
+    ].map(filename => downloadCanBridgeArtifact(filename)));
     console.log("CANBridge download completed");
+
+    
     console.log("Extracting headers");
-
+    const zipFiles = fs.readdirSync(tempDir).filter(filename => filename.endsWith('.zip') && filename !== 'headers.zip');
+    for (const filename of zipFiles) { 
+        await unzipCanBridgeArtifact(filename, tempDir);
+    }
     const headersZip = new AdmZip(path.join(tempDir, "headers.zip"));
+    headersZip.extractAllTo(path.join(externalCompileTimeDepsPath, 'include'));
+    console.log("Headers extracted");
 
-    await headersZip.extractAllTo(path.join(externalCompileTimeDepsPath, 'include'));
+    moveRuntimeDeps();
+
+    moveCompileTimeDeps();
 } catch (e) {
     if (axios.isAxiosError(e) && e.request) {
-        console.error(`Failed to download CANBridge file ${e.request.protocol}//${e.request.host}/${e.request.path}`);
+        console.error(`Failed to download CANBridge file ${e.request.protocol}//${e.request.host}${e.request.path}`);
     } else {
-        console.error(`Failed to download CANBridge`);
+        console.error(`Other error occurred: ${e.message}`);
         // For non-axios errors, the stacktrace will likely be helpful
         throw e;
     }
     process.exit(1);
 } finally {
     if (fs.existsSync(tempDir)) {
-        fs.rmSync(tempDir, { recursive: true });
+        fs.rmSync(tempDir, { recursive: true, force: true});
     }
 }
 
-async function downloadCanBridgeArtifact(filename, destDir) {
+/**
+ * Move external compile time dependencies to the correct directory
+ * 
+ * This function is used to move the external compile time dependencies to the correct directory based on the platform and architecture from downloaded artifacts
+ */
+function moveCompileTimeDeps() {
+    console.log("Moving external compile time dependencies to correct directories");
+    if (platform() === 'win32') {
+        const deps = ['CANBridge.lib', 'wpiHal.lib', 'wpiutil.lib'];
+        deps.forEach(dep => moveExternalCompileTimeDeps(path.join('win32-x64', dep)));
+    } else if (platform() === 'darwin') {
+        const deps = ['libCANBridge.a'];
+        const archDepMap = {
+            x64: 'darwin-x64',
+            arm64: 'darwin-arm64'
+        };
+        deps.forEach(dep => moveExternalCompileTimeDeps(path.join(archDepMap[arch()], dep)));
+    } else if (platform() === 'linux') {
+        const deps = ['libCANBridge.a'];
+        const archDepMap = {
+            x64: 'linux-x64',
+            arm64: 'linux-arm64',
+            arm: 'linux-arm32'
+        };
+        deps.forEach(dep => moveExternalCompileTimeDeps(path.join(archDepMap[arch()], dep)));
+    }
+    console.log("External compile time dependencies moved to correct directories");
+}
+
+/**
+ * Move runtime dependencies to the correct directory
+ * 
+ * This function is used to move the runtime dependencies to the correct directory based on the platform and architecture from downloaded artifacts
+ */
+function moveRuntimeDeps() {
+    console.log("Moving artifacts to correct directories");
+    if (platform() === 'win32') {
+        const deps = ['CANBridge.dll', 'wpiHal.dll', 'wpiutil.dll'];
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('win32-x64', dep), runtimeArtifactsPath.win));
+    } else if (platform() === 'darwin') {
+        const deps = ['libCANBridge.dylib', 'libwpiHal.dylib', 'libwpiutil.dylib'];
+        const archDepMap = {
+            x64: runtimeArtifactsPath.osx,
+            arm64: runtimeArtifactsPath.osxArm
+        };
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join(archDepMap[arch()], dep), archDepMap[arch()]));
+    } else if (platform() === 'linux') {
+        const deps = ['libCANBridge.so', 'libwpiHal.so', 'libwpiutil.so'];
+        const archDepMap = {
+            x64: runtimeArtifactsPath.linux,
+            arm64: runtimeArtifactsPath.linuxArm,
+            arm: runtimeArtifactsPath.linuxArm32
+        };
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join(archDepMap[arch()], dep), archDepMap[arch()]));
+    }
+    console.log("CANBridge artifacts moved to correct directories");
+}
+
+/**
+ * Download artifacts from the CANBridge GitHub release page
+ * 
+ * @param {*} filename filename of the artifact to download
+ * @param {*} destDir destination directory to save the artifact, defaults to tempDir
+ */
+async function downloadCanBridgeArtifact(filename, destDir = tempDir) {
     fs.mkdirSync(destDir, { recursive: true });
     const response = await axios.get(`${canBridgeReleaseAssetUrlPrefix}/${filename}`, { responseType: "stream" });
     const fileStream = fs.createWriteStream(`${destDir}/${filename}`);
@@ -50,4 +131,42 @@ async function downloadCanBridgeArtifact(filename, destDir) {
     await new Promise(resolve => {
         fileStream.on('finish', resolve);
     });
+}
+
+/**
+ * Unzip the CANBridge artifacts
+ * 
+ * @param {string} filename - filename of the artifact to unzip
+ * @param {string} destDir - destination directory to unzip the artifact
+ */
+async function unzipCanBridgeArtifact(filename, destDir) {
+    const zip = new AdmZip(`${destDir}/${filename}`);
+    let filepath;
+    if (filename.includes('linuxarm32')) filepath = "linux-arm32";
+    else if (filename.includes('linuxarm64')) filepath = "linux-arm64";
+    else if (filename.includes('linuxx86-64')) filepath = "linux-x64";
+    else if (filename.includes('MacOS64')) filepath = "darwin-x64";
+    else if (filename.includes('MacOSARM64')) filepath = "darwin-arm64";
+    else if (filename.includes('windowsx86-64')) filepath = "win32-x64";
+    zip.extractAllTo(`${destDir}/${filepath}`);
+}
+
+/**
+ * Move runtime artifacts to the correct directory
+ * 
+ * @param {*} filename filename of the artifact to move
+ * @param {*} destDir destination directory to save the artifact
+ */
+function moveRuntimeArtifactsDeps(filename, destDir) {
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.renameSync(path.join(tempDir, filename), path.join(destDir, path.basename(filename)));
+}
+
+/**
+ * Move External Compile Time Dependencies to the correct directory
+ * 
+ * @param {*} filename filename of the artifact to move
+ */
+function moveExternalCompileTimeDeps(filename) {
+    fs.renameSync(path.join(tempDir, filename), path.join(externalCompileTimeDepsPath, path.basename(filename)));
 }

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -54,9 +54,9 @@ try {
     }
     process.exit(1);
 } finally {
-    if (fs.existsSync(tempDir)) {
-        fs.rmSync(tempDir, { recursive: true, force: true});
-    }
+    //if (fs.existsSync(tempDir)) {
+    //    fs.rmSync(tempDir, { recursive: true, force: true});
+    //}
 }
 
 /**
@@ -66,6 +66,9 @@ try {
  */
 function moveCompileTimeDeps() {
     console.log("Moving external compile time dependencies to correct directories");
+    if (!fs.existsSync(externalCompileTimeDepsPath)) {
+        fs.mkdirSync(externalCompileTimeDepsPath, { recursive: true });
+    }
     if (platform() === 'win32') {
         const deps = ['CANBridge.lib', 'wpiHal.lib', 'wpiutil.lib'];
         deps.forEach(dep => moveExternalCompileTimeDeps(path.join('win32-x64', dep)));
@@ -95,24 +98,31 @@ function moveCompileTimeDeps() {
  */
 function moveRuntimeDeps() {
     console.log("Moving artifacts to correct directories");
+    if (!fs.existsSync('prebuilds')) {
+        fs.mkdirSync('prebuilds', { recursive: true });
+    }
     if (platform() === 'win32') {
         const deps = ['CANBridge.dll', 'wpiHal.dll', 'wpiutil.dll'];
         deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('win32-x64', dep), runtimeArtifactsPath.win));
     } else if (platform() === 'darwin') {
         const deps = ['libCANBridge.dylib', 'libwpiHal.dylib', 'libwpiutil.dylib'];
-        const archDepMap = {
-            x64: runtimeArtifactsPath.osx,
-            arm64: runtimeArtifactsPath.osxArm
-        };
-        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join(archDepMap[arch()], dep), archDepMap[arch()]));
+        if (arch() === 'x64') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-x64', dep), runtimeArtifactsPath.osx));
+        }
+        if (arch() === 'arm64') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-arm64', dep), runtimeArtifactsPath.osxArm));
+        }
     } else if (platform() === 'linux') {
         const deps = ['libCANBridge.so', 'libwpiHal.so', 'libwpiutil.so'];
-        const archDepMap = {
-            x64: runtimeArtifactsPath.linux,
-            arm64: runtimeArtifactsPath.linuxArm,
-            arm: runtimeArtifactsPath.linuxArm32
-        };
-        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join(archDepMap[arch()], dep), archDepMap[arch()]));
+        if (arch() === 'x64') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('linux-x64', dep), runtimeArtifactsPath.linux));
+        }
+        if (arch() === 'arm64') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('linux-arm64', dep), runtimeArtifactsPath.linuxArm));
+        }
+        if (arch() === 'arm') {
+            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('linux-arm32', dep), runtimeArtifactsPath.linuxArm32));
+        }
     }
     console.log("CANBridge artifacts moved to correct directories");
 }

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -4,14 +4,13 @@ import axios from 'axios';
 import AdmZip from 'adm-zip';
 import { platform, arch } from 'os';
 
-const canBridgeTag = "v2.3.1";
+const canBridgeTag = "v2.3.2";
 const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';
 const runtimeArtifactsPath = {
     win: 'prebuilds/win32-x64',
-    osx: 'prebuilds/darwin-x64',
-    osxArm: 'prebuilds/darwin-arm64',
+    osx: 'prebuilds/darwin-osxuniversal',
     linux: 'prebuilds/linux-x64',
     linuxArm: 'prebuilds/linux-arm64',
     linuxArm32: 'prebuilds/linux-arm32'
@@ -21,11 +20,10 @@ const tempDir = 'temp';
 try {
     // TODO: Do not hardcode the filenames, instead get them from the GitHub API -> Look at Octokit: https://github.com/octokit/octokit.js
     await Promise.all([
-        'CANBridge-linuxarm32-LinuxARM32.zip',
-        'CANBridge-linuxarm64-LinuxARM64.zip',
+        'CANBridge-linuxarm32.zip',
+        'CANBridge-linuxarm64.zip',
         'CANBridge-linuxx86-64-Linux64.zip',
-        'CANBridge-osxuniversal-MacOS64.zip',
-        'CANBridge-osxuniversal-MacOSARM64.zip',
+        'CANBridge-osxuniversal-macOS.zip',
         'CANBridge-windowsx86-64-Win64.zip',
         'headers.zip'
     ].map(filename => downloadCanBridgeArtifact(filename)));
@@ -74,11 +72,7 @@ function moveCompileTimeDeps() {
         deps.forEach(dep => moveExternalCompileTimeDeps(path.join('win32-x64', dep)));
     } else if (platform() === 'darwin') {
         const deps = ['libCANBridge.a'];
-        const archDepMap = {
-            x64: 'darwin-x64',
-            arm64: 'darwin-arm64'
-        };
-        deps.forEach(dep => moveExternalCompileTimeDeps(path.join(archDepMap[arch()], dep)));
+        deps.forEach(dep => moveExternalCompileTimeDeps(path.join('darwin-osxuniversal', dep)));
     } else if (platform() === 'linux') {
         const deps = ['libCANBridge.a'];
         const archDepMap = {
@@ -106,7 +100,7 @@ function moveRuntimeDeps() {
         deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('win32-x64', dep), runtimeArtifactsPath.win));
     } else if (platform() === 'darwin') {
         const deps = ['libCANBridge.dylib', 'libwpiHal.dylib', 'libwpiutil.dylib'];
-        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-x64', dep), runtimeArtifactsPath.osx));
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-osxuniversal', dep), runtimeArtifactsPath.osx));
     } else if (platform() === 'linux') {
         const deps = ['libCANBridge.so', 'libwpiHal.so', 'libwpiutil.so'];
         if (arch() === 'x64') {
@@ -150,8 +144,7 @@ async function unzipCanBridgeArtifact(filename, destDir) {
     if (filename.includes('linuxarm32')) filepath = "linux-arm32";
     else if (filename.includes('linuxarm64')) filepath = "linux-arm64";
     else if (filename.includes('linuxx86-64')) filepath = "linux-x64";
-    else if (filename.includes('MacOS64')) filepath = "darwin-x64";
-    else if (filename.includes('MacOSARM64')) filepath = "darwin-arm64";
+    else if (filename.includes('osxuniversal')) filepath = "darwin-osxuniversal";
     else if (filename.includes('windowsx86-64')) filepath = "win32-x64";
     zip.extractAllTo(`${destDir}/${filepath}`);
 }

--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -106,12 +106,7 @@ function moveRuntimeDeps() {
         deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('win32-x64', dep), runtimeArtifactsPath.win));
     } else if (platform() === 'darwin') {
         const deps = ['libCANBridge.dylib', 'libwpiHal.dylib', 'libwpiutil.dylib'];
-        if (arch() === 'x64') {
-            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-x64', dep), runtimeArtifactsPath.osx));
-        }
-        if (arch() === 'arm64') {
-            deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-arm64', dep), runtimeArtifactsPath.osxArm));
-        }
+        deps.forEach(dep => moveRuntimeArtifactsDeps(path.join('darwin-x64', dep), runtimeArtifactsPath.osx));
     } else if (platform() === 'linux') {
         const deps = ['libCANBridge.so', 'libwpiHal.so', 'libwpiutil.so'];
         if (arch() === 'x64') {

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -768,3 +768,11 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
     }
 }
 
+/**
+ * This function was removed from commit b0ca096624286b1e975eaaa816e38599933b7e84, which broke MSVC builds.
+ * It has been re-added here to fix the build.
+ */
+void stopHeartbeats(const Napi::CallbackInfo& info) {
+    //! TODO: Reimplement this function with current codebase
+    Napi::Env env = info.Env();
+}

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -239,7 +239,7 @@ Napi::Object receiveMessage(const Napi::CallbackInfo& info) {
     size_t messageSize = message->GetSize();
     const uint8_t* messageData = message->GetData();
     Napi::Array napiMessage = Napi::Array::New(env, messageSize);
-    for (int i = 0; i < messageSize; i++) {
+    for (size_t i = 0; i < messageSize; i++) {
         napiMessage[i] =  messageData[i];
     }
     Napi::Object messageInfo = Napi::Object::New(env);
@@ -332,7 +332,7 @@ Napi::Number openStreamSession(const Napi::CallbackInfo& info) {
     try {
         rev::usb::CANStatus status = device->OpenStreamSession(&sessionHandle, filter, maxSize);
         if (status != rev::usb::CANStatus::kOk) {
-            Napi::Error::New(env, "Opening stream session failed with error code "+(int)status).ThrowAsJavaScriptException();
+            Napi::Error::New(env, "Opening stream session failed with error code "+std::to_string((int)status)).ThrowAsJavaScriptException();
         } else {
             return Napi::Number::New(env, sessionHandle);
         }
@@ -661,7 +661,7 @@ void heartbeatsWatchdog() {
         {
             // Erase removed CAN buses from heartbeatsRunning
             std::scoped_lock lock{watchdogMtx, canDevicesMtx};
-            for(int i = 0; i < heartbeatsRunning.size(); i++) {
+            for(size_t i = 0; i < heartbeatsRunning.size(); i++) {
                 auto deviceIterator = canDeviceMap.find(heartbeatsRunning[i]);
                 if (deviceIterator == canDeviceMap.end()) {
                     heartbeatsRunning.erase(heartbeatsRunning.begin() + i);
@@ -678,7 +678,7 @@ void heartbeatsWatchdog() {
         if (elapsed_seconds.count() > 1) {
             uint8_t sparkMaxHeartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
             uint8_t revCommonHeartbeat[] = {0};
-            for(int i = 0; i < heartbeatsRunning.size(); i++) {
+            for(size_t i = 0; i < heartbeatsRunning.size(); i++) {
                 _sendCANMessage(heartbeatsRunning[i], 0x2052C80, sparkMaxHeartbeat, 8, -1);
                 _sendCANMessage(heartbeatsRunning[i], 0x00502C0, revCommonHeartbeat, 1, -1);
             }
@@ -714,7 +714,7 @@ void startRevCommonHeartbeat(const Napi::CallbackInfo& info) {
         std::thread hb(heartbeatsWatchdog);
         hb.detach();
     } else {
-        for(int i = 0; i < heartbeatsRunning.size(); i++) {
+        for(size_t i = 0; i < heartbeatsRunning.size(); i++) {
             if (heartbeatsRunning[i].compare(descriptor) == 0) return;
         }
         heartbeatsRunning.push_back(descriptor);
@@ -760,7 +760,7 @@ void setSparkMaxHeartbeatData(const Napi::CallbackInfo& info) {
             std::thread hb(heartbeatsWatchdog);
             hb.detach();
         } else {
-            for(int i = 0; i < heartbeatsRunning.size(); i++) {
+            for(size_t i = 0; i < heartbeatsRunning.size(); i++) {
                 if (heartbeatsRunning[i].compare(descriptor) == 0) return;
             }
             heartbeatsRunning.push_back(descriptor);


### PR DESCRIPTION
Major refactor of the `download-CanBridge.mjs` script.

Points to the correct repository now instead of the upstream repository.

Added proper support for macOS, Linux, ARM64, and ARM32 based systems.

Rewrote handling artifacts from unzipping, to moving artifacts to correct directories based on what platforms are downloaded and what is currently running on.

Added documentation to helper functions.

Closes #2 and #3