### PR TITLE
ci: Remove `setuptools` step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,10 @@ jobs:
       with:
         node-version: '20'
 
-    - uses: actions/setup-python@v5
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-
-    - name: Install Python setup tools
-      run: |
-          pip install setuptools
 
     - name: Install dependencies
       run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  build:
+  release:
     strategy:
       fail-fast: false
       matrix:
@@ -22,12 +22,10 @@ jobs:
       with:
         node-version: '20'
 
-    - uses: actions/setup-python@v5
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: Install Python setup tools
-      run: |
-          pip install setuptools
 
     - name: Install dependencies
       run: npm install


### PR DESCRIPTION
Removal of `setuptools` install step due to bumped `node-gyp` version.