### PR TITLE
Add support for SocketCAN for Linux platforms

### DIFF
--- a/scripts/download-CanBridge.mjs
+++ b/scripts/download-CanBridge.mjs
@@ -4,7 +4,7 @@ import axios from 'axios';
 import AdmZip from 'adm-zip';
 import { platform, arch } from 'os';
 
-const canBridgeTag = "v2.3.6";
+const canBridgeTag = "v2.4.0";
 const canBridgeReleaseAssetUrlPrefix = `https://github.com/unofficial-rev-port/CANBridge/releases/download/${canBridgeTag}`;
 
 const externalCompileTimeDepsPath = 'externalCompileTimeDeps';

--- a/src/SocketCANDeviceWrapper.h
+++ b/src/SocketCANDeviceWrapper.h
@@ -1,0 +1,37 @@
+#include <rev/Drivers/SocketCAN/SocketCANDevice.h>
+#include <napi.h>
+#include <typeinfo>
+#include <iostream>
+
+class NapiWinUSBDevice : public Napi::ObjectWrap<NapiSocketCANDevice> {
+  public:
+    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+    NapiSocketCANDevice(const Napi::CallbackInfo& info);
+    Napi::Value GetName(const Napi::CallbackInfo& info);
+    void SetDevice(std::unique_ptr<rev::usb::CANDevice>);
+
+  private:
+    std::unique_ptr<rev::usb::CANDevice> device;
+};
+
+Napi::Object NapiSocketCANDevice::Init(Napi::Env env, Napi::Object exports) {
+    Napi::Function func = DefineClass(env, "NapiSocketCANDevice", {
+        InstanceMethod("GetName", &NapiSocketCANDevice::GetName)
+    });
+
+    Napi::FunctionReference* constructor = new Napi::FunctionReference();
+    *constructor = Napi::Persistent(func);
+    exports.Set("NapiSocketCANDevice", func);
+
+    return exports;
+}
+
+NapiSocketCANDevice::NapiSocketCANDevice(const Napi::CallbackInfo& info) : Napi::ObjectWrap<NapiSocketCANDevice>(info) {
+    Napi::Env env = info.Env();
+    std::cout << "Creating device " << std::endl;
+}
+
+Napi::Value NapiSocketCANDevice::GetName(const Napi::CallbackInfo& info){
+    Napi::Env env = info.Env();
+    return Napi::String::New(env, this->device->GetName());
+}

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -37,7 +37,11 @@
 uint8_t disabledSparkHeartbeat[] = {0, 0, 0, 0, 0, 0, 0, 0};
 uint8_t disabledRevCommonHeartbeat[] = {0};
 
+#ifdef _WIN32
 rev::usb::CandleWinUSBDriver* driver = new rev::usb::CandleWinUSBDriver();
+#elif __linux__
+rev::usb::SocketCANDriver* driver = new rev::usb::SocketCANDriver();
+#endif
 
 std::set<std::string> devicesRegisteredToHal; // TODO(Noah): Protect with mutex
 bool halInitialized = false;

--- a/src/canWrapper.cc
+++ b/src/canWrapper.cc
@@ -3,8 +3,13 @@
 #include <rev/CANMessage.h>
 #include <rev/CANStatus.h>
 #include <rev/CANBridgeUtils.h>
+#ifdef _WIN32
 #include <rev/Drivers/CandleWinUSB/CandleWinUSBDriver.h>
 #include <rev/Drivers/CandleWinUSB/CandleWinUSBDevice.h>
+#elif __linux__
+#include <rev/Drivers/SocketCAN/SocketCANDriver.h>
+#include <rev/Drivers/SocketCAN/SocketCANDevice.h>
+#endif
 #include <utils/ThreadUtils.h>
 #include <hal/HAL.h>
 #include <hal/CAN.h>


### PR DESCRIPTION
SocketCAN support is dependent on merging https://github.com/unofficial-rev-port/CANBridge/pull/5.

Should resolve Linux-related #12.